### PR TITLE
Upgrade to ddtrace 1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in .gemspec
 gemspec
 
-gem 'ddtrace', '1.0'
+gem 'ddtrace', '~>1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in .gemspec
 gemspec
 
-gem 'ddtrace', '>=0.11.0'
+gem 'ddtrace', '1.0'

--- a/benchmark/run.rb
+++ b/benchmark/run.rb
@@ -1,6 +1,6 @@
 require 'ddtrace'
 require 'benchmark'
-require_relative './lib/ddtrace_method_wrapper'
+require_relative '../lib/ddtrace_method_wrapper'
 
 n = 100_000
 
@@ -17,28 +17,28 @@ end
 
 class DatadogTraceWrapperBenchmarkManualInstrumentation
   def method
-    Datadog.tracer.trace('benchmark') do
+    Datadog::Tracing.trace('benchmark') do
     end
   end
 end
 
 Benchmark.bm do |benchmark|
   benchmark.report("configured class init and execute") do
-    Datadog.configuration.tracer.enabled = true
+    Datadog.configuration.tracing.enabled = true
     n.times do
       DatadogTraceWrapperBenchmarkWrapped.new.method
     end
   end
 
   benchmark.report("configured class init and execute enabled=false") do
-    Datadog.configuration.tracer.enabled = false
+    Datadog.configuration.tracing.enabled = false
     n.times do
       DatadogTraceWrapperBenchmarkWrapped.new.method
     end
   end
 
   benchmark.report("manual instrumentation class execute") do
-    Datadog.configuration.tracer.enabled = true
+    Datadog.configuration.tracing.enabled = true
     n.times do
       DatadogTraceWrapperBenchmarkManualInstrumentation.new.method
     end
@@ -51,7 +51,7 @@ Benchmark.bm do |benchmark|
   end
 
   benchmark.report("configured class execute") do
-    Datadog.configuration.tracer.enabled = true
+    Datadog.configuration.tracing.enabled = true
     inst = DatadogTraceWrapperBenchmarkWrapped.new
     n.times do
       inst.method
@@ -59,7 +59,7 @@ Benchmark.bm do |benchmark|
   end
 
   benchmark.report("configured class execute enabled=false") do
-    Datadog.configuration.tracer.enabled = false
+    Datadog.configuration.tracing.enabled = false
     inst = DatadogTraceWrapperBenchmarkWrapped.new
     n.times do
       inst.method
@@ -67,7 +67,7 @@ Benchmark.bm do |benchmark|
   end
 
   benchmark.report("manual instrumentation class execute") do
-    Datadog.configuration.tracer.enabled = true
+    Datadog.configuration.tracing.enabled = true
     inst = DatadogTraceWrapperBenchmarkManualInstrumentation.new
     n.times do
       inst.method

--- a/lib/datadog_trace_wrapper.rb
+++ b/lib/datadog_trace_wrapper.rb
@@ -1,7 +1,6 @@
 # CoreUsage:
 # extend DatadogTraceWrapper
 module DatadogTraceWrapper
-
   # Instructs the class to wrap methods for custom datadog tracing
   #
   # == Parameters:
@@ -22,13 +21,12 @@ module DatadogTraceWrapper
   #   Keyword arguments passed through to Datadog.tracer.trace, listed here:
   #   https://docs.datadoghq.com/tracing/setup_overview/setup/ruby/#manual-instrumentation
   def trace(*method_names, span_type:, service: nil, resource: nil, **trace_kwargs)
-
     method_names.each do |m|
       proxy = Module.new do
         define_method(m) do |*args, **kwargs|
           service  ||= ENV['DD_TRACE_METHOD_WRAPPER_SERVICE']
-          resource ||= "#{self.class.name}##{m.to_s}"
-          Datadog.tracer.trace(
+          resource ||= "#{self.class.name}##{m}"
+          Datadog::Tracing.trace(
             span_type,
             service: service,
             resource: resource,
@@ -39,7 +37,7 @@ module DatadogTraceWrapper
         end
       end
 
-      self.prepend proxy
+      prepend proxy
     end
   end
 end


### PR DESCRIPTION
This is a breaking change to upgrade to ddtrace `v1.x`.

Based on the [Upgrade Guide](https://github.com/DataDog/dd-trace-rb/blob/master/docs/UpgradeGuide.md).